### PR TITLE
Remove end_epoch option

### DIFF
--- a/config.py
+++ b/config.py
@@ -58,7 +58,6 @@ def get_parser():
     # 학습 파라미터
     parser.add_argument('--batch_size', type=int, default=128, help='Batch size')
     parser.add_argument('--if_scratch', action='store_true', help='If training from scratch')
-    parser.add_argument('--end_epoch', type=int, default=30, help='Number of epochs')
     parser.add_argument('--epochs', type=int, default=30, help='Number of epochs')
     parser.add_argument('--lr', type=float, default=0.0005, help='Learning rate')
     parser.add_argument('--weight_decay', type=float, default=0.001, help='Weight decay')

--- a/main.py
+++ b/main.py
@@ -332,7 +332,7 @@ def main():
     early_stopping = args.early_stopping
     batch_size = args.batch_size
     num_classes = args.num_classes
-    end_epoch = args.end_epoch
+    epochs = args.epochs
     if_scratch = args.if_scratch
     
     if finetune_mode:
@@ -370,7 +370,7 @@ def main():
         )
         
         wandb_config = {
-            "epochs": end_epoch,
+            "epochs": epochs,
             "batch_size": batch_size,
             "learning_rate": lr,
             "weight_decay": weight_decay,
@@ -455,9 +455,9 @@ def main():
         logger.info(f"{'Fine-tuning' if finetune_mode else 'Training'} started with {dataset_text}")
         training_start_time = time.time()
         
-        for epoch in range(begin_epoch, end_epoch):
+        for epoch in range(begin_epoch, epochs):
             start_time = time.time()
-            logger.info(f"\n===== Epoch {epoch + 1}/{end_epoch} =====")
+            logger.info(f"\n===== Epoch {epoch + 1}/{epochs} =====")
             
             train_loss, train_accuracy = train_one_epoch(model, dataloaders['train'], optimizer, criterion)
             
@@ -491,7 +491,7 @@ def main():
             
             epoch_time = time.time() - start_time
             logger.info(f"Epoch {epoch + 1} completed in {epoch_time:.2f} seconds.")
-            logger.info(f"Epoch {epoch+1}/{end_epoch} - Train Loss: {train_loss:.4f}, Train Acc: {train_accuracy:.4f}, Val Loss: {val_loss:.4f}, Val Acc: {val_accuracy:.4f}, Val F1: {val_f1:.4f}",)
+            logger.info(f"Epoch {epoch+1}/{epochs} - Train Loss: {train_loss:.4f}, Train Acc: {train_accuracy:.4f}, Val Loss: {val_loss:.4f}, Val Acc: {val_accuracy:.4f}, Val F1: {val_f1:.4f}",)
             
             scheduler.step(val_loss)
             

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ python processing/preprocess.py
 ## Model Training and Evaluation
 ### Training
 ```bash
-python main.py --mode train --if_scratch --batch_size 128 --end_epoch 30
+python main.py --mode train --if_scratch --batch_size 128 --epochs 30
 ```
 ### Testing
 ```bash
@@ -57,7 +57,7 @@ python main.py --mode train_and_test --if_scratch
 --mode: Execution mode (train, test, train_and_test)
 --if_scratch: Whether to train from scratch
 --batch_size: Batch size
---end_epoch: Maximum training epochs
+--epochs: Maximum training epochs
 --lr: Learning rate
 --seq_len: Sequence length (default: 240)
 --d_model: Model dimension (default: 128)


### PR DESCRIPTION
## Summary
- delete deprecated `--end_epoch` arg
- switch to `epochs` variable in main training loop
- mention `--epochs` usage in docs

## Testing
- `python -m py_compile config.py main.py`
- `python main.py --help` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_683ff76607a883228d28e4e3337da61a