### PR TITLE
Add run_name to checkpoint filename

### DIFF
--- a/main.py
+++ b/main.py
@@ -325,7 +325,8 @@ def main():
     num_workers = args.num_workers
     checkpoint_dir = args.checkpoint_dir
     log_name = args.log_name
-    checkpoint_path = os.path.join(checkpoint_dir, 'checkpoint.pth')
+    run_name = f"{log_name}_{mode}" if finetune_mode else log_name
+    checkpoint_path = os.path.join(checkpoint_dir, f"{run_name}.pth")
     
     lr = args.lr
     weight_decay = args.weight_decay
@@ -342,7 +343,7 @@ def main():
         lr = lr / 10 if args.finetune_lr is None else args.finetune_lr
         # pretrained 체크포인트 경로 (기본 체크포인트와 다를 수 있음)
         pretrained_checkpoint = checkpoint_dir
-        pretrained_checkpoint_path = os.path.join(pretrained_checkpoint, 'checkpoint.pth')
+        pretrained_checkpoint_path = os.path.join(pretrained_checkpoint, f"{log_name}.pth")
     
 
     
@@ -382,7 +383,6 @@ def main():
             "mode": mode
         }
         wandb.config.update(wandb_config)
-        run_name = f"{log_name}_{mode}" if finetune_mode else log_name
         wandb.run.name = run_name
         
         # 손실 함수, 옵티마이저 설정

--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,9 @@ python main.py --mode test
 ```bash
 python main.py --mode train_and_test --if_scratch
 ```
+Checkpoints are stored in `checkpoint/{run_name}.pth`. The `run_name` is based
+on the `--log_name` argument (and `--mode` when fine-tuning) so multiple runs do
+not overwrite each other.
 
 ## Key Parameters
 ```


### PR DESCRIPTION
## Summary
- include `run_name` when constructing checkpoint path
- use the new filename when loading checkpoints
- mention updated behaviour in README

## Testing
- `python -m py_compile main.py config.py`


------
https://chatgpt.com/codex/tasks/task_e_683ff7ea91f88322ae898ccc366a4f98