### PR TITLE
Add run_name logging option

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,5 +1,6 @@
 import argparse
 import sys
+import time
 
 def get_parser():
     parser = argparse.ArgumentParser(description="Process EDF files to extract ECG and THOR RES signals.")
@@ -73,6 +74,8 @@ def get_parser():
     parser.add_argument('--result_dir', type=str, default='results', help='Directory to save results')
     parser.add_argument('--checkpoint_dir', type=str, default='checkpoint', help='Directory to save output files')
     parser.add_argument('--log_name', type=str, default='train', help='Log file name')
+    parser.add_argument('--run_name', type=str, default=time.strftime('%Y%m%d_%H%M%S'),
+                        help='Unique run name for checkpoints and logs')
     parser.add_argument('--gpu_ids', nargs='+', default=[0], help='GPU IDs to use')
     parser.add_argument('--preprocess_log_dir', type=str, default='processing/preprocess_log', help='Directory to save preprocessing logs')
     

--- a/data/KVSS.py
+++ b/data/KVSS.py
@@ -11,8 +11,8 @@ from config import parse_args
 from tqdm import tqdm
 
 # 로깅 설정
-logger = Logger(dir='output/log', name='SleepVST.kvss_loader')
 args = parse_args()
+logger = Logger(dir='output/log', name='SleepVST.kvss_loader', run_name=args.run_name)
 
 def process_file(hw_path, seq_len, step=10):
     """

--- a/data/MESA.py
+++ b/data/MESA.py
@@ -11,8 +11,8 @@ from config import parse_args
 from tqdm import tqdm
 
 # 로깅 설정
-logger = Logger(dir='output/log', name='SleepVST.mesa_loader')
 args = parse_args()
+logger = Logger(dir='output/log', name='SleepVST.mesa_loader', run_name=args.run_name)
 
 def process_file(hw_path, seq_len, step=10):
     """

--- a/data/SHHS.py
+++ b/data/SHHS.py
@@ -10,8 +10,8 @@ from utils.customlogger import Logger
 from config import parse_args
 from tqdm import tqdm
 
-logger = Logger(dir='output/log', name='SleepVST.shhs_loader')
 args = parse_args()
+logger = Logger(dir='output/log', name='SleepVST.shhs_loader', run_name=args.run_name)
 
 def process_file(hw_path, seq_len, step=10):
     """

--- a/main.py
+++ b/main.py
@@ -325,7 +325,8 @@ def main():
     num_workers = args.num_workers
     checkpoint_dir = args.checkpoint_dir
     log_name = args.log_name
-    checkpoint_path = os.path.join(checkpoint_dir, 'checkpoint.pth')
+    run_name = args.run_name
+    checkpoint_path = os.path.join(checkpoint_dir, f"{run_name}_checkpoint.pth")
     
     lr = args.lr
     weight_decay = args.weight_decay
@@ -349,7 +350,7 @@ def main():
     # Logger 설정
     if not os.path.exists('output/log'):
         os.makedirs('output/log')
-    logger = Logger(dir='output/log', name='SleepVST' + '.train')
+    logger = Logger(dir='output/log', name='SleepVST.train', run_name=run_name)
     
     if not os.path.exists(checkpoint_dir):
         os.makedirs(checkpoint_dir)
@@ -382,8 +383,8 @@ def main():
             "mode": mode
         }
         wandb.config.update(wandb_config)
-        run_name = f"{log_name}_{mode}" if finetune_mode else log_name
-        wandb.run.name = run_name
+        wandb_run_name = f"{log_name}_{mode}" if finetune_mode else log_name
+        wandb.run.name = wandb_run_name
         
         # 손실 함수, 옵티마이저 설정
         criterion = nn.CrossEntropyLoss().cuda()
@@ -502,7 +503,7 @@ def main():
                 # Fine-tuning일 경우 다른 이름으로 저장
                 save_path = checkpoint_path
                 if finetune_mode:
-                    save_path = os.path.join(checkpoint_dir, 'kvss_finetuned_checkpoint.pth')
+                    save_path = os.path.join(checkpoint_dir, f"{run_name}_kvss_finetuned_checkpoint.pth")
                 
                 torch.save({
                     'epoch': epoch,
@@ -541,7 +542,7 @@ def main():
                 logger.error(f"No checkpoint found at {checkpoint_path}. Cannot test.")
                 return
         elif 'train' not in mode and use_kvss:
-            checkpoint_path = os.path.join(checkpoint_dir, 'kvss_finetuned_checkpoint.pth')
+            checkpoint_path = os.path.join(checkpoint_dir, f"{run_name}_kvss_finetuned_checkpoint.pth")
             logger.info(f"Fine-tuning mode: Loading model from {checkpoint_path}")
             if os.path.exists(checkpoint_path):
                 checkpoint = torch.load(checkpoint_path)
@@ -552,7 +553,7 @@ def main():
                 return
         
         # 테스트 로거 설정
-        test_logger = Logger(dir='output/log', name='SleepVST' + '.test')
+        test_logger = Logger(dir='output/log', name='SleepVST.test', run_name=run_name)
         
         if use_shhs_mesa:
             criterion = nn.CrossEntropyLoss().cuda()

--- a/preprocess_SNUH.py
+++ b/preprocess_SNUH.py
@@ -24,7 +24,7 @@ from tqdm import tqdm
 # 전역 변수로 executor 선언
 executor = None
 args = config.parse_args()
-logger = Logger(dir=args.preprocess_log_dir, name='SleepVST.preprocess')
+logger = Logger(dir=args.preprocess_log_dir, name='SleepVST.preprocess', run_name=args.run_name)
 
 def signal_handler(sig, frame):
     """

--- a/processing/preprocess.py
+++ b/processing/preprocess.py
@@ -23,7 +23,7 @@ from tqdm import tqdm
 # 전역 변수로 executor 선언
 executor = None
 args = config.parse_args()
-logger = Logger(dir=args.preprocess_log_dir, name='SleepVST.preprocess')
+logger = Logger(dir=args.preprocess_log_dir, name='SleepVST.preprocess', run_name=args.run_name)
 
 def signal_handler(sig, frame):
     """

--- a/transfer_learning.py
+++ b/transfer_learning.py
@@ -10,6 +10,7 @@ from utils.customlogger import Logger
 from utils.util import MetricsTracker, AverageMeter
 import wandb
 import argparse
+import time
 
 def parse_args():
     parser = argparse.ArgumentParser(description='SleepVST Transfer Learning')
@@ -22,6 +23,8 @@ def parse_args():
     parser.add_argument('--epochs', type=int, default=50, help='Number of epochs')
     parser.add_argument('--num_classes', type=int, default=4, help='Number of target classes')
     parser.add_argument('--output_dir', type=str, default='transfer_checkpoints', help='Output directory')
+    parser.add_argument('--run_name', type=str, default=time.strftime('%Y%m%d_%H%M%S'),
+                        help='Unique run name for logs and checkpoints')
     parser.add_argument('--use_wandb', action='store_true', help='Use wandb for logging')
     return parser.parse_args()
 
@@ -66,7 +69,7 @@ def freeze_layers(model, freeze_encoder=False, freeze_transformer=False):
 
 def transfer_learning(args):
     # 로거 설정
-    logger = Logger(dir='output/log', name=f'SleepVST_transfer_{args.target_dataset}')
+    logger = Logger(dir='output/log', name=f'SleepVST_transfer_{args.target_dataset}', run_name=args.run_name)
     
     # 모델 로드
     logger.info(f"Loading source model from {args.source_ckpt}")
@@ -187,7 +190,7 @@ def transfer_learning(args):
             best_val_acc = val_acc
             
             # 체크포인트 저장
-            checkpoint_path = os.path.join(args.output_dir, f"best_model_{args.target_dataset}.pth")
+            checkpoint_path = os.path.join(args.output_dir, f"{args.run_name}_best_model_{args.target_dataset}.pth")
             torch.save({
                 'epoch': epoch,
                 'model_state_dict': model.state_dict(),

--- a/utils/customlogger.py
+++ b/utils/customlogger.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 class Logger():
-    def __init__(self, dir, name='SleepVST', level=logging.DEBUG):
+    def __init__(self, dir, name='SleepVST', run_name=None, level=logging.DEBUG):
         """
         :param dir: 로그 파일을 저장할 디렉토리
         :param name: 로그 파일 이름
@@ -43,7 +43,10 @@ class Logger():
         self.logger.setLevel(logging.INFO)
 
         # 로그 파일 핸들러 설정
-        log_file = os.path.join(dir, name)
+        filename = name
+        if run_name:
+            filename = f"{name}_{run_name}"
+        log_file = os.path.join(dir, filename + ".log")
         if not os.path.exists(dir):
             os.makedirs(dir)
         fh = logging.FileHandler(log_file)

--- a/utils/util.py
+++ b/utils/util.py
@@ -3,8 +3,10 @@ from utils.customlogger import Logger
 import xml.etree.ElementTree as ET
 from sklearn.metrics import accuracy_score, f1_score, confusion_matrix, cohen_kappa_score, classification_report
 import csv
+from config import parse_args
 
-logger = Logger(dir='output/log', name='SleepVST.mesa_loader')
+args = parse_args()
+logger = Logger(dir='output/log', name='SleepVST.mesa_loader', run_name=args.run_name)
 
 class MetricsTracker:
     def __init__(self):


### PR DESCRIPTION
## Summary
- allow passing a `--run_name` argument to control names of logs and checkpoints
- attach the run name when creating log files
- use the run name when saving checkpoints

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683ff7d24ce48322b15fbf9f217e1d6f